### PR TITLE
Drop support for Rails 7.1 and Ruby 2.7 and 3.0

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,28 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
         gemfile: [
-          dev/gemfiles/rails-7.1.x.gemfile,
           dev/gemfiles/rails-7.2.x.gemfile,
           dev/gemfiles/rails-8.0.x.gemfile,
           Gemfile
         ]
         exclude:
-          # Exclude rubies < 3.1 for ActiveModel ~> 7.2
-          - ruby: "2.7"
-            gemfile: dev/gemfiles/rails-7.2.x.gemfile
-          - ruby: "3.0"
-            gemfile: dev/gemfiles/rails-7.2.x.gemfile
-          # Exclude rubies < 3.2 for ActiveModel ~> 8.0
-          - ruby: "2.7"
-            gemfile: dev/gemfiles/rails-8.0.x.gemfile
-          - ruby: "2.7"
-            gemfile: Gemfile
-          - ruby: "3.0"
-            gemfile: dev/gemfiles/rails-8.0.x.gemfile
-          - ruby: "3.0"
-            gemfile: Gemfile
+          # Exclude rubies < 3.2 for ActiveModel < 8.0
           - ruby: "3.1"
             gemfile: dev/gemfiles/rails-8.0.x.gemfile
           - ruby: "3.1"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ plugins:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.1
   NewCops: enable
 
 Naming/FileName:

--- a/dev/gemfiles/rails-7.1.x.gemfile
+++ b/dev/gemfiles/rails-7.1.x.gemfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-
-gemspec path: '../..'
-gem 'activemodel', '~> 7.1.0'
-gem 'bigdecimal'
-gem 'logger'
-gem 'mutex_m'

--- a/postcode_validator.gemspec
+++ b/postcode_validator.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
     f.match(excluded_dirs) || excluded_files.include?(f)
   end
 
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = '>= 3.1'
 
   spec.add_dependency 'twitter_cldr', '> 4.4.0'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,4 +37,4 @@ RSpec.configure do |config|
   end
 end
 
-Dir[File.join(__dir__, 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[File.join(__dir__, 'support', '**', '*.rb')].each { |f| require f }


### PR DESCRIPTION
1. Drop support for Rails 7.1 as it's not supported anymore.
2. Update the test matrix to not include deprecated rubies previously required by Rails 7.1